### PR TITLE
newline-before-return Regel auf true gesetzt.

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -22,7 +22,7 @@
     * Vertikales Alignment für Variablen, Anweisungen und Parameter (align)
     * Radix Parameter bei parseInt muss nicht immer angegeben werden (radix)
     * Geschweifte Klammern müssen immer gesetzt werden (curly)
-    * Es muss keine Leerzeile vor einer Return-Anweisung stehen (newline-before-return)
+    * Es muss eine Leerzeile vor einer Return-Anweisung stehen (newline-before-return)
     * Var Keyword ist verboten (no-var-keyword)
 * Codelyzer Regeln
     * Gelten nicht für FormBox-API, da es sich um spezielle Regeln für Angular handelt

--- a/tslint.json
+++ b/tslint.json
@@ -186,7 +186,7 @@
 			true,
 			"ignore-comments"
 		],
-        "newline-before-return": false,
+        "newline-before-return": true,
         "no-var-keyword": true,
         "one-line": [
             true,


### PR DESCRIPTION
zu den zusätzlichen Fehlern in tslint..

Fehler: "'@param' is redundant in TypeScript code if it has no description." 

laut http://usejsdoc.org/tags-param.html sollte das möglich sein,
also @param nameDesParameters,
wahlweise name und Type: @param {DexieStorage} nameDesParameters
oder name,type und beschreibung: @param {DexieStorage} nameDesParameters Das ist eine Beschreibung. 

MMn sollte das kein Fehler sein, ebenso wie der Fehler "JSDoc tag '@constructor' is redundant in TypeScript code."

Ich hätte noch gerne ausprobiert ob evtl. damit gemeint ist das @constructor ganz wegelassen wird wenn constructer() {} so bezeichnet ist und der Constructor "automatisch" erkannt wird.

Wenn ich lokal in formbox "ng lint" starte erhalte ich als Fehler nur "Calls to 'console.log' are not allowed." (wie in sonar), die anderen Meldungen allerdings nicht.  

Habe ich evtl. noch etwas übersehen?

Noch eine Sache die ich nicht ganz auscchließen will.. ich habe ab und an schon wildes verhalten von software gesehen wenn wegen Speicherplatzmangel etwas nicht richtig gebaut wird, kann es evtl. auch daran liegen und die unterschiedliche Ausgabe lokal und Sonar erklären?

Jenkins log: Betrifft im moment nur das formbox projekt wo auch die lint fehler aufpoppen.
program state save failed
java.io.IOException: No space left on device
	at java.io.FileOutputStream.writeBytes(Native Method)
	at java.io.FileOutputStream.write(FileOutputStream.java:326)
	at java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:82)
	at java.io.BufferedOutputStream.write(BufferedOutputStream.java:126)
	at java.io.DataOutputStream.write(DataOutputStream.java:107)
	at org.jboss.marshalling.OutputStreamByteOutput.write(OutputStreamByteOutput.java:52)
	at org.jboss.marshalling.SimpleDataOutput.flush(SimpleDataOutput.java:336)
	at org.jboss.marshalling.SimpleDataOutput.finish(SimpleDataOutput.java:378)
	at org.jboss.marshalling.AbstractMarshaller.finish(AbstractMarshaller.java:126)
	at org.jenkinsci.plugins.workflow.support.pickles.serialization.RiverWriter.close(RiverWriter.java:151)
	at org.jenkinsci.plugins.workflow.cps.CpsThreadGroup.saveProgram(CpsThreadGroup.java:461)
Caused: java.io.IOException: Failed to persist /var/lib/jenkins/jobs/FormBox/branches/PR-4/builds/23/program.dat

Was mir noch aufgefallen ist und mmn eine Nachfrage wert ist.. in Jenkins -> Manage Jenkins -> Global Tool Configuration -> NodeJS installations ist node 6.11.3 als version angegeben, ist ja doch etwas überholt, macht es Sinn das auf die Version einzustellen die auch am Entwicklungsrechner verwendet wird (wenn man sich einigt auf den Dev-Rechnern mit einer einheitlichen Version zu arbeiten).


Leider gerade mehr fragen als Antworten, wäre super wenn wir das nächste woche besprechen könnten. 
Danke, an alle ein schönes WE.

