### PR TITLE
Redux-Remote-Debugging.

### DIFF
--- a/docs/redux.md
+++ b/docs/redux.md
@@ -32,16 +32,41 @@ Zum schnellen Erstellen von den für Redux benötigten Klassen gibt es einen Gen
 
 Mit dem Befehl werden Dateien für State, Actions, Reducers, und Epics angelegt.
 Das Argument `<name>` wird dabei als Basis für die Namen der Dateien und Klassen
-verwendet.  
+verwendet.
 
-## Redux Developer Tool
+## Redux Remote Developer Tool
 
-FormBox unterstützt die [Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension) für Firefox und Chrome. Dafür muss FormBox im Browser gestartet werden.
-Wenn die Extension installiert ist, hat das Kontextmenü des Browsers einen Eintrag 'Redux DevTools' über den man die DevTools öffnen kann.
+FormBox unterstützt die [Redux DevTools Extension](https://github.com/zalmoxisus/redux-devtools-extension) für Firefox und Chrome.
+Wenn die Extension installiert ist, hat das Kontextmenü des Browsers einen Eintrag `'Redux DevTools' -> 'Open Remote DevTools'` über den man die DevTools öffnen kann.
+
+Damit Redux-Remote-Debugging funktioniert muss eine Instanz von remotedev-server auf einem Server mit NodeJs-Installation gestartet werden.
+
+Folgende NPM-Pakete müssen global installiert werden:
+
+ `npm install -g remotedev-server`
+ `npm install -g socketcluster`
+
+Remote-Server starten: `remotedev --hostname=0.0.0.0 --port=12556 --protocol=https --key=/pfad_cert_key/cert.key --cert=/pfad_cert_crt/cert.crt &`
+
+Hinweis: Evtl. muss der Port durch Portfreigabe/Firewall freigegeben werden.
+
+Formbox baut beim Start eine Verbindung (Websockets) mit dem remotedev-server auf, remotedev-server reicht die entsprechenden Daten an die "Redux Remote DevTools" auf dem Client weiter.
+
+#### Konfiguration Redux-Remote-DevTool
+
+###### Settings:
+
+ `Hostname: SERVER_URL`
+ `Port: 12556`
+ `Use Secure connection: AN`
+
+ Formbox benötigt für eine erfolgreiche Verbindung zum remotedev-server ebenfalls Verbindungsdaten und
+ werden über environment-Variablen gesetzt.
 
 ## Dokumentation
 
 * [Redux](https://redux.js.org/)
+* [Redux RemoteDev-Server](https://github.com/zalmoxisus/remotedev-server)
 * [angular-redux/store](https://github.com/angular-redux/store)
 * [Tutorial](https://github.com/angular-redux/store/blob/master/articles/intro-tutorial.md)
 * [Ribosome](http://sustrik.github.io/ribosome/) (Codegenerator)

--- a/docs/redux.md
+++ b/docs/redux.md
@@ -50,7 +50,7 @@ Remote-Server starten: `remotedev --hostname=0.0.0.0 --port=12556 --protocol=htt
 
 Hinweis: Evtl. muss der Port durch Portfreigabe/Firewall freigegeben werden.
 
-Formbox baut beim Start eine Verbindung (Websockets) mit dem remotedev-server auf, remotedev-server reicht die entsprechenden Daten an die "Redux Remote DevTools" auf dem Client weiter.
+Formbox baut beim Start eine Verbindung (Websockets) mit dem remotedev-server auf. Remotedev-server reicht die entsprechenden Daten an die Client-Anwendung "Redux Remote DevTools" weiter.
 
 #### Konfiguration Redux-Remote-DevTool
 
@@ -60,8 +60,8 @@ Formbox baut beim Start eine Verbindung (Websockets) mit dem remotedev-server au
  `Port: 12556`
  `Use Secure connection: AN`
 
- Formbox benötigt für eine erfolgreiche Verbindung zum remotedev-server ebenfalls Verbindungsdaten und
- werden über environment-Variablen gesetzt.
+ Für eine erfolgreiche Verbindung zum remotedev-server benötigt Formbox ebenfalls Verbindungsdaten welche
+ über environment-Variablen gesetzt werden.
 
 ## Dokumentation
 

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "node-sass": "^4.8.3",
     "randomcolor": "^0.5.3",
     "redux": "^3.7.2",
+    "redux-devtools-extension": "^2.13.2",
     "redux-observable": "^0.17.0",
     "reflect-metadata": "^0.1.12",
     "remote-redux-devtools": "^0.5.12",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "redux": "^3.7.2",
     "redux-observable": "^0.17.0",
     "reflect-metadata": "^0.1.12",
+    "remote-redux-devtools": "^0.5.12",
     "romanize": "^1.1.1",
     "rxjs": "^5.5.6",
     "sax": "^1.2.4",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,6 +71,7 @@ import { FormularGuiActions } from './store/actions/formular-gui-actions';
 import { KomfortdruckComponent } from './components/komfortdruck/komfortdruck.component';
 import { OnCreateDirective } from './directives/on-create.directive';
 import { TooltipModule } from 'ngx-bootstrap/tooltip';
+import { composeWithDevTools } from 'remote-redux-devtools';
 
 @NgModule({
   declarations: [
@@ -157,7 +158,8 @@ export class AppModule {
     if (environment.production || !environment.test) {
       ngRedux.configureStore(rootReducer, INITIAL_STATE, middleware);
     } else {
-      ngRedux.configureStore(rootReducer, INITIAL_STATE, middleware, devTools.enhancer());
+      const composeEnhancers = composeWithDevTools({ realtime: true });
+      ngRedux.provideStore(createStore(rootReducer, INITIAL_STATE, composeEnhancers(applyMiddleware(...middleware))));
     }
 
     this.init.initSLV();

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -155,10 +155,12 @@ export class AppModule {
     const middleware = [
       createEpicMiddleware(this.rootEpic.epics())
     ];
+
     if (environment.production || !environment.test) {
       ngRedux.configureStore(rootReducer, INITIAL_STATE, middleware);
     } else {
-      const composeEnhancers = composeWithDevTools({ realtime: true });
+      const composeEnhancers = composeWithDevTools({ realtime: true, hostname: environment.reduxRemoteUrl,
+                                                     port: environment.reduxRemotePort, secure: environment.reduxRemoteSecure });
       ngRedux.provideStore(createStore(rootReducer, INITIAL_STATE, composeEnhancers(applyMiddleware(...middleware))));
     }
 

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -4,5 +4,8 @@ export const environment = {
   production: true,
   formboxapi: 'https://kvm-javabuild.tvc.muenchen.de/formbox-standard-api',
   loglevel: Level.INFO,
-  test: false
+  test: false,
+  reduxRemoteUrl: undefined,
+  reduxRemotePort: undefined,
+  reduxRemoteSecure: undefined
 };

--- a/src/environments/environment.test.ts
+++ b/src/environments/environment.test.ts
@@ -4,5 +4,8 @@ export const environment = {
   production: false,
   test: true,
   formboxapi: 'https://localhost:4201',
-  loglevel: Level.LOG
+  loglevel: Level.LOG,
+  reduxRemoteUrl: undefined,
+  reduxRemotePort: undefined,
+  reduxRemoteSecure: undefined
 };

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -9,5 +9,8 @@ export const environment = {
   test: false,
   production: false,
   formboxapi: 'https://localhost:4201',
-  loglevel: Level.LOG
+  loglevel: Level.LOG,
+  reduxRemoteUrl: 'kvm-javabuild.tvc.muenchen.de',
+  reduxRemotePort: 12556,
+  reduxRemoteSecure: true
 };


### PR DESCRIPTION
Redux debugging funktioniert jetzt auch mit 'npm start', also auch in Office.
Damit das klappt Browser öffnen -> rechte Maustaste -> Redux Devtools -> Open Remote DevTools.
Damit das funktioniert baut redux-dev-tools eine websocket-Verbindung zu remotedev.io auf,
Hr. Sikeler und meine Wenigkeit waren aber eher dafür das über einen eigenen Server zu machen um keine relevanten Daten nach außen zu geben, um den Remote-Server lokal zu starten müsste aber noch etwas Zeit investiert werden und webpack konfiguriert werden.

Ich habe das jetzt mal zum ausprobieren so gelassen.

Remote-Dev-Server lokal einrichten:
https://github.com/zalmoxisus/remotedev-server

Problem: Remote-Dev-Server vewendet SocketCluster, webpack muss dafür konfiguriert werden.
https://github.com/SocketCluster/socketcluster/issues/287