### PR TITLE
use not updated firefox version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,10 @@ pipeline {
 
     tools {nodejs 'node6.11.3'}
 
+    environment {
+      FIREFOX_BIN = "/opt/firefox/firefox"
+    }
+
     stages {
         stage('Build') {
             steps {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -13,13 +13,14 @@ exports.config = {
     'browserName': 'firefox',
     'marionette': true,
     'firefoxOptions': {
+      binary: process.env.FIREFOX_BIN,
       args: [ '--headless' ]
     },
     'moz:firefoxOptions': {
+      binary: process.env.FIREFOX_BIN,
       args: [ '--headless' ]
     }
   },
-  firefoxPath: process.env.FIREFOX_BIN,
   directConnect: true,
   framework: 'jasmine',
   jasmineNodeOpts: {

--- a/protractor.conf.js
+++ b/protractor.conf.js
@@ -19,6 +19,7 @@ exports.config = {
       args: [ '--headless' ]
     }
   },
+  firefoxPath: process.env.FIREFOX_BIN,
   directConnect: true,
   framework: 'jasmine',
   jasmineNodeOpts: {


### PR DESCRIPTION
Nach einem Update des Servers hat Firefox im Headless Mode nicht mehr funktioniert. Deswegen verwenden wir eine ältere Version. Hier wurden die Pfade dafür konfiguriert.